### PR TITLE
fix: global variables in AMPIdentifyInterceptor

### DIFF
--- a/Sources/Amplitude/AMPIdentifyInterceptor.m
+++ b/Sources/Amplitude/AMPIdentifyInterceptor.m
@@ -39,18 +39,18 @@
 #import "AMPIdentifyInterceptor.h"
 #import "AMPDatabaseHelper.h"
 
-@implementation AMPIdentifyInterceptor
-
-NSArray *_Nonnull _interceptOps;
-NSSet *_Nonnull _interceptOpsSet;
-BOOL _transferScheduled;
-NSOperationQueue *_Nonnull _backgroundQueue;
-AMPDatabaseHelper *_Nonnull _dbHelper;
-BOOL _hasIdentity;
-NSString *_Nullable _userId;
-NSString *_Nullable _deviceId;
-int _interceptedUploadPeriodSeconds;
-BOOL _disabled;
+@implementation AMPIdentifyInterceptor {
+    NSArray *_Nonnull _interceptOps;
+    NSSet *_Nonnull _interceptOpsSet;
+    BOOL _transferScheduled;
+    NSOperationQueue *_Nonnull _backgroundQueue;
+    AMPDatabaseHelper *_Nonnull _dbHelper;
+    BOOL _hasIdentity;
+    NSString *_Nullable _userId;
+    NSString *_Nullable _deviceId;
+    int _interceptedUploadPeriodSeconds;
+    BOOL _disabled;
+}
 
 -(id)initWithParams:(AMPDatabaseHelper *_Nonnull)dbHelper
     backgroundQueue:(NSOperationQueue *_Nonnull)backgroundQueue
@@ -255,6 +255,10 @@ BOOL _disabled;
 
 - (void)setDisabled:(BOOL)disable {
     _disabled = disable;
+}
+
+- (AMPDatabaseHelper *)dbHelper {
+    return _dbHelper;
 }
 
 @end

--- a/Tests/IdentifyInterceptorTests.m
+++ b/Tests/IdentifyInterceptorTests.m
@@ -12,6 +12,10 @@
 #import "AMPIdentify.h"
 #import "AMPIdentifyInterceptor.h"
 
+@interface AMPIdentifyInterceptor(PrivateTests)
+- (AMPDatabaseHelper *)dbHelper;
+@end
+
 @interface IdentifyInterceptorTests : XCTestCase
 
 @property AMPIdentifyInterceptor *identifyInterceptor;
@@ -491,5 +495,18 @@
     XCTAssertTrue([userProperties[AMP_OP_SET][@"set-key"] isEqualToString:@"set-value-a"]);
     XCTAssertTrue([userProperties[AMP_OP_SET][@"set-key-2"] isEqualToString:@"set-value-c"]);
     XCTAssertNil(userProperties[AMP_OP_SET][@"set-key-3"]);
+}
+
+- (void)testDbHelperIsNotReusedAcrossDifferentIdentifyInterceptorInstances {
+    AMPDatabaseHelper *dbHelper1 = [AMPDatabaseHelper getDatabaseHelper:@"dbHelper1"];
+    AMPIdentifyInterceptor *identifyInterceptor1 = [AMPIdentifyInterceptor getIdentifyInterceptor:dbHelper1
+                                                                                  backgroundQueue:[[NSOperationQueue alloc] init]];
+
+    AMPDatabaseHelper *dbHelper2 = [AMPDatabaseHelper getDatabaseHelper:@"dbHelper2"];
+    AMPIdentifyInterceptor *identifyInterceptor2 = [AMPIdentifyInterceptor getIdentifyInterceptor:dbHelper2
+                                                                                  backgroundQueue:[[NSOperationQueue alloc] init]];
+
+    XCTAssertIdentical(identifyInterceptor1.dbHelper, dbHelper1);
+    XCTAssertIdentical(identifyInterceptor2.dbHelper, dbHelper2);
 }
 @end


### PR DESCRIPTION
AMPIdentifyInterceptor declares variables in @implementation section without wrapping them in curly brackets {}. That makes variables global instead of instance variables.

Using multiple instances of Amplitude leads to creating multiple instances of AMPIdentifyInterceptor, which shares global variables like dbHelper. In result one dbHelper will be used by all instances of AMPIdentifyInterceptor -> some user properties will be attached to wrong instance of Amplitude (to the latter one).

Only user properties logging was affected. Event logging was not affected.

<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
